### PR TITLE
Use 'commander' instead of 'minimist' -- it's just too bare bones

### DIFF
--- a/jerry-debugger/package.json
+++ b/jerry-debugger/package.json
@@ -20,12 +20,13 @@
   "private": false,
   "dependencies": {
     "chrome-remote-debug-protocol": "^1.2.20170721",
-    "minimist": "^1.2.0",
+    "commander": "^2.15.0",
     "noice-json-rpc": "^1.1.1",
     "uuid": "^3.2.1",
     "ws": "^3.3.2"
   },
   "devDependencies": {
+    "@types/commander": "^2.12.2",
     "@types/jest": "^22.1.2",
     "@types/minimist": "^1.2.0",
     "@types/node": "^9.4.6",

--- a/jerry-debugger/src/cli/__tests__/index.test.ts
+++ b/jerry-debugger/src/cli/__tests__/index.test.ts
@@ -13,79 +13,91 @@
 // limitations under the License.
 
 import { getOptionsFromArgs } from '../cli';
+import {
+  DEFAULT_DEBUGGER_HOST,
+  DEFAULT_DEBUGGER_PORT,
+} from '../../lib/debugger-client';
+import {
+  DEFAULT_SERVER_HOST,
+  DEFAULT_SERVER_PORT,
+} from '../../lib/cdt-proxy';
 
 describe('getOptionsFromArgs', () => {
 
+  function getOptionsFromUserArgs(userArgs: string[]) {
+    return getOptionsFromArgs(['node', 'jerry-debugger.js'].concat(userArgs));
+  }
+
   it('works without --inspect-brk', () => {
-    const opt = getOptionsFromArgs([]);
-    expect(opt.proxyAddress.host).toEqual(undefined);
-    expect(opt.proxyAddress.port).toEqual(undefined);
+    const opt = getOptionsFromUserArgs([]);
+    expect(opt.proxyAddress.host).toEqual(DEFAULT_SERVER_HOST);
+    expect(opt.proxyAddress.port).toEqual(DEFAULT_SERVER_PORT);
   });
 
   it('parses --inspect-brk with port only', () => {
-    const opt = getOptionsFromArgs(['--inspect-brk=1234']);
+    const opt = getOptionsFromUserArgs(['--inspect-brk=1234']);
     expect(opt.proxyAddress.host).toEqual(undefined);
     expect(opt.proxyAddress.port).toEqual(1234);
   });
 
   it('parses --inspect-brk with no port', () => {
-    const opt = getOptionsFromArgs(['--inspect-brk=10.10.10.10:']);
+    const opt = getOptionsFromUserArgs(['--inspect-brk=10.10.10.10:']);
     expect(opt.proxyAddress.host).toEqual('10.10.10.10');
     expect(opt.proxyAddress.port).toEqual(undefined);
   });
 
   it('parses --inspect-brk with no host', () => {
-    const opt = getOptionsFromArgs(['--inspect-brk=:1234']);
+    const opt = getOptionsFromUserArgs(['--inspect-brk=:1234']);
     expect(opt.proxyAddress.host).toEqual(undefined);
     expect(opt.proxyAddress.port).toEqual(1234);
   });
 
   it('parses --inspect-brk with host and port', () => {
-    const opt = getOptionsFromArgs(['--inspect-brk=10.10.10.10:1234']);
+    const opt = getOptionsFromUserArgs(['--inspect-brk=10.10.10.10:1234']);
     expect(opt.proxyAddress.host).toEqual('10.10.10.10');
     expect(opt.proxyAddress.port).toEqual(1234);
   });
 
   it('works without --jerry-remote', () => {
-    const opt = getOptionsFromArgs([]);
-    expect(opt.remoteAddress.host).toEqual(undefined);
-    expect(opt.remoteAddress.port).toEqual(undefined);
+    const opt = getOptionsFromUserArgs([]);
+    expect(opt.remoteAddress.host).toEqual(DEFAULT_DEBUGGER_HOST);
+    expect(opt.remoteAddress.port).toEqual(DEFAULT_DEBUGGER_PORT);
   });
 
   it('parses --jerry-remote with port only', () => {
-    const opt = getOptionsFromArgs(['--jerry-remote=1234']);
+    const opt = getOptionsFromUserArgs(['--jerry-remote=1234']);
     expect(opt.remoteAddress.host).toEqual(undefined);
     expect(opt.remoteAddress.port).toEqual(1234);
   });
 
   it('parses --jerry-remote with host and port', () => {
-    const opt = getOptionsFromArgs(['--jerry-remote=10.10.10.10:1234']);
+    const opt = getOptionsFromUserArgs(['--jerry-remote=10.10.10.10:1234']);
     expect(opt.remoteAddress.host).toEqual('10.10.10.10');
     expect(opt.remoteAddress.port).toEqual(1234);
   });
 
   it('verbose defaults to false', () => {
-    const opt = getOptionsFromArgs([]);
+    const opt = getOptionsFromUserArgs([]);
     expect(opt.verbose).toEqual(false);
   });
 
   it('parses verbose flag', () => {
-    const opt = getOptionsFromArgs(['--verbose']);
+    const opt = getOptionsFromUserArgs(['--verbose']);
     expect(opt.verbose).toEqual(true);
   });
 
   it('parses v alias for verbose', () => {
-    const opt = getOptionsFromArgs(['-v']);
+    const opt = getOptionsFromUserArgs(['-v']);
     expect(opt.verbose).toEqual(true);
   });
 
   it('jsfile defaults to untitled.js', () => {
-    const opt = getOptionsFromArgs([]);
+    const opt = getOptionsFromUserArgs([]);
     expect(opt.jsfile).toEqual('untitled.js');
   });
 
   it('returns client source as jsfile', () => {
-    const opt = getOptionsFromArgs(['foo/bar.js']);
+    const opt = getOptionsFromUserArgs(['foo/bar.js']);
     expect(opt.jsfile).toEqual('foo/bar.js');
   });
 

--- a/jerry-debugger/yarn.lock
+++ b/jerry-debugger/yarn.lock
@@ -16,6 +16,12 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
+"@types/commander@^2.12.2":
+  version "2.12.2"
+  resolved "https://registry.yarnpkg.com/@types/commander/-/commander-2.12.2.tgz#183041a23842d4281478fa5d23c5ca78e6fd08ae"
+  dependencies:
+    commander "*"
+
 "@types/events@*":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-1.1.0.tgz#93b1be91f63c184450385272c47b6496fd028e02"
@@ -563,6 +569,10 @@ combined-stream@1.0.6, combined-stream@^1.0.5, combined-stream@~1.0.5:
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.6.tgz#723e7df6e801ac5613113a7e445a9b69cb632818"
   dependencies:
     delayed-stream "~1.0.0"
+
+commander@*, commander@^2.15.0:
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.0.tgz#ad2a23a1c3b036e392469b8012cec6b33b4c1322"
 
 commander@^2.12.1:
   version "2.14.1"


### PR DESCRIPTION
Now you can actually do basic stuff like `--help`:

```
$ ./jerry-debugger.sh --help

  Usage: jerry-debugger [options] <script.js ...>

  Options:

    -v, --verbose                 Enable verbose logging
    --inspect-brk [[host:]port]   Activate Chrome DevTools proxy on host:port (default: localhost:9229)
    --jerry-remote [[host:]port]  Connect to JerryScript on host:port (default: localhost:5001)
    -h, --help                    output usage information
```

JerryScript-DCO-1.0-Signed-off-by: Martjin The martijn.the@intel.com