### PR TITLE
report resume events to CDT

### DIFF
--- a/jerry-debugger/src/lib/cdt-controller.ts
+++ b/jerry-debugger/src/lib/cdt-controller.ts
@@ -56,6 +56,13 @@ export class CDTController {
     }
   }
 
+  onResume() {
+    // this can happen before the proxy is connected
+    if (this.proxyServer) {
+      this.proxyServer.sendResumed();
+    }
+  }
+
   // CDTDelegate functions
 
   // 'request' functions are information requests from CDT to Debugger

--- a/jerry-debugger/src/lib/cdt-proxy.ts
+++ b/jerry-debugger/src/lib/cdt-proxy.ts
@@ -190,4 +190,8 @@ export class ChromeDevToolsProxyServer {
       callFrames: [callFrame],
     });
   }
+
+  sendResumed() {
+    this.api.Debugger.emitResumed();
+  }
 }

--- a/jerry-debugger/src/lib/protocol-handler.ts
+++ b/jerry-debugger/src/lib/protocol-handler.ts
@@ -39,6 +39,7 @@ export interface JerryDebugProtocolDelegate {
   onError?(code: number, message: string): void;
   onScriptParsed?(message: JerryMessageScriptParsed): void;
   onBreakpointHit?(message: JerryMessageBreakpointHit): void;
+  onResume?(): void;
 }
 
 export interface JerryMessageScriptParsed {
@@ -406,6 +407,10 @@ export class JerryDebugProtocolHandler {
     if (!this.lastBreakpointHit) {
       throw new Error('attempted resume while not at breakpoint');
     }
+    this.lastBreakpointHit = undefined;
     this.debuggerClient!.send(encodeMessage(this.byteConfig, 'B', [code]));
+    if (this.delegate.onResume) {
+      this.delegate.onResume();
+    }
   }
 }


### PR DESCRIPTION
This fixes the message in CDT to not always show 'Debugger paused'.

JerryScript-DCO-1.0-Signed-off-by: Geoff Gustafson geoff@linux.intel.com