### PR TITLE
Add support for eval command to support watch variables

### DIFF
--- a/jerry-debugger/src/lib/__tests__/cdt-controller.test.ts
+++ b/jerry-debugger/src/lib/__tests__/cdt-controller.test.ts
@@ -106,32 +106,6 @@ describe('onEvalResult', () => {
   });
 
   it('calls resolve for successful eval', () => {
-    const promise = controller.cmdEvaluate({
-      expression: 'valid',
-    });
-    controller.onEvalResult(JERRY_DEBUGGER_EVAL_OK, 'success');
-    return expect(promise).resolves.toEqual({
-      result: {
-        type: 'string',
-        value: 'success',
-      },
-    });
-  });
-
-  it('calls reject for failed eval', () => {
-    const promise = controller.cmdEvaluate({
-      expression: 'invalid',
-    });
-    controller.onEvalResult(JERRY_DEBUGGER_EVAL_ERROR, 'failure');
-    return expect(promise).rejects.toEqual({
-      result: {
-        type: 'string',
-        value: 'failure',
-      },
-    });
-  });
-
-  it('calls resolve for successful eval on call frame', () => {
     const promise = controller.cmdEvaluateOnCallFrame({
       callFrameId: '0',
       expression: 'valid',
@@ -145,7 +119,7 @@ describe('onEvalResult', () => {
     });
   });
 
-  it('calls reject for failed eval on call frame', () => {
+  it('calls reject for failed eval', () => {
     const promise = controller.cmdEvaluateOnCallFrame({
       callFrameId: '0',
       expression: 'invalid',

--- a/jerry-debugger/src/lib/__tests__/protocol-handler.test.ts
+++ b/jerry-debugger/src/lib/__tests__/protocol-handler.test.ts
@@ -183,7 +183,7 @@ describe('onSourceCodeName', () => {
 });
 
 describe('releaseFunction', () => {
-  it('', () => {
+  it('updates functions, lineLists, and activeBreakpoints', () => {
     const byteCodeCP = 0;
     const func = {
       scriptId: 7,

--- a/jerry-debugger/src/lib/__tests__/protocol-handler.test.ts
+++ b/jerry-debugger/src/lib/__tests__/protocol-handler.test.ts
@@ -383,13 +383,6 @@ describe('getScriptIdByName', () => {
 });
 
 describe('evaluate', () => {
-  it('stores expression in queue if not at breakpoint', () => {
-    const handler = new JerryDebugProtocolHandler({});
-    (handler as any).evalQueue = [];
-    handler.evaluate('foo');
-    expect((handler as any).evalQueue).toEqual(['foo']);
-  });
-
   it('sends single eval packet for short expressions', () => {
     const debugClient = {
       send: jest.fn(),

--- a/jerry-debugger/src/lib/__tests__/utils.test.ts
+++ b/jerry-debugger/src/lib/__tests__/utils.test.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { getFormatSize, getUint32, setUint32, decodeMessage, encodeMessage,
-  cesu8ToString, assembleUint8Arrays } from '../utils';
+  cesu8ToString, stringToCesu8, assembleUint8Arrays } from '../utils';
 
 const defConfig = {
   cpointerSize: 2,
@@ -263,9 +263,14 @@ describe('encodeMessage', () => {
   });
 });
 
-describe('cesu8ToString', () => {
+describe('cesu8ToString and stringToCesu8', () => {
   it('returns empty string for undefined input', () => {
     expect(cesu8ToString(undefined)).toEqual('');
+  });
+
+  it('returns empty array for empty string, and vice versa', () => {
+    expect(cesu8ToString(new Uint8Array(0))).toEqual('');
+    expect(stringToCesu8('')).toEqual(new Uint8Array(0));
   });
 
   it('returns ASCII from ASCII', () => {
@@ -275,6 +280,7 @@ describe('cesu8ToString', () => {
       array[i] = sentence.charCodeAt(i);
     }
     expect(cesu8ToString(array)).toEqual(sentence);
+    expect(stringToCesu8(sentence)).toEqual(array);
   });
 
   it('acts like UTF-8 for two-byte encodings', () => {
@@ -284,6 +290,8 @@ describe('cesu8ToString', () => {
     const highTwoByte = Uint8Array.from([0xc0 + 0x1f, 0x80 + 0x3f]);
     expect(cesu8ToString(lowTwoByte)).toEqual(String.fromCharCode(0x80));
     expect(cesu8ToString(highTwoByte)).toEqual(String.fromCharCode(0x7ff));
+    expect(stringToCesu8(String.fromCharCode(0x80))).toEqual(lowTwoByte);
+    expect(stringToCesu8(String.fromCharCode(0x7ff))).toEqual(highTwoByte);
   });
 
   it('acts like UTF-8 for three-byte encodings', () => {
@@ -293,6 +301,8 @@ describe('cesu8ToString', () => {
     const highThreeByte = Uint8Array.from([0xe0 + 0x0f, 0x80 + 0x3f, 0x80 + 0x3f]);
     expect(cesu8ToString(lowThreeByte)).toEqual(String.fromCharCode(0x0800));
     expect(cesu8ToString(highThreeByte)).toEqual(String.fromCharCode(0xffff));
+    expect(stringToCesu8(String.fromCharCode(0x0800))).toEqual(lowThreeByte);
+    expect(stringToCesu8(String.fromCharCode(0xffff))).toEqual(highThreeByte);
   });
 
   it('decodes UTF-16 surrogate pairs', () => {
@@ -305,6 +315,7 @@ describe('cesu8ToString', () => {
       0xe0 + 0x0d, 0x80 + 0x38, 0x80 + 0x02,
     ]);
     expect(cesu8ToString(surrogatePairBytes)).toEqual('😂');
+    expect(stringToCesu8('😂')).toEqual(surrogatePairBytes);
   });
 });
 

--- a/jerry-debugger/src/lib/cdt-controller.ts
+++ b/jerry-debugger/src/lib/cdt-controller.ts
@@ -149,13 +149,6 @@ export class CDTController {
   }
 
   // 'cmd' functions are commands from CDT to Debugger
-  cmdEvaluate(request: Crdp.Runtime.EvaluateRequest): Promise<Crdp.Runtime.EvaluateResponse> {
-    this.protocolHandler!.evaluate(request.expression);
-    return new Promise((resolve, reject) => {
-      this.evalResolvers.push({ resolve, reject });
-    });
-  }
-
   cmdEvaluateOnCallFrame(request: Crdp.Debugger.EvaluateOnCallFrameRequest): Promise<Crdp.Runtime.EvaluateResponse> {
     // FIXME: actually evaluate on call frame someday
     this.protocolHandler!.evaluate(request.expression);

--- a/jerry-debugger/src/lib/cdt-proxy.ts
+++ b/jerry-debugger/src/lib/cdt-proxy.ts
@@ -30,8 +30,6 @@ export interface CDTDelegate {
     Promise<Crdp.Debugger.GetPossibleBreakpointsResponse>;
   requestScriptSource: (request: Crdp.Debugger.GetScriptSourceRequest) =>
     Promise<Crdp.Debugger.GetScriptSourceResponse>;
-  cmdEvaluate: (request: Crdp.Runtime.EvaluateRequest) =>
-    Promise<Crdp.Runtime.EvaluateResponse>;
   cmdEvaluateOnCallFrame: (request: Crdp.Debugger.EvaluateOnCallFrameRequest) =>
     Promise<Crdp.Debugger.EvaluateOnCallFrameResponse>;
   cmdPause: () => void;
@@ -132,7 +130,6 @@ export class ChromeDevToolsProxyServer {
     this.api.Profiler.expose({ enable: notImplemented });
     this.api.Runtime.expose({
       enable: notImplemented,
-      evaluate: request => this.delegate.cmdEvaluate(request),
       runIfWaitingForDebugger: async () => {
         // how could i chain this to happen after the enable response goes out?
         this.api.Runtime.emitExecutionContextCreated({

--- a/jerry-debugger/src/lib/cdt-proxy.ts
+++ b/jerry-debugger/src/lib/cdt-proxy.ts
@@ -30,6 +30,10 @@ export interface CDTDelegate {
     Promise<Crdp.Debugger.GetPossibleBreakpointsResponse>;
   requestScriptSource: (request: Crdp.Debugger.GetScriptSourceRequest) =>
     Promise<Crdp.Debugger.GetScriptSourceResponse>;
+  cmdEvaluate: (request: Crdp.Runtime.EvaluateRequest) =>
+    Promise<Crdp.Runtime.EvaluateResponse>;
+  cmdEvaluateOnCallFrame: (request: Crdp.Debugger.EvaluateOnCallFrameRequest) =>
+    Promise<Crdp.Debugger.EvaluateOnCallFrameResponse>;
   cmdPause: () => void;
   cmdRemoveBreakpoint: (breakpointId: number) => Promise<void>;
   cmdResume: () => void;
@@ -103,6 +107,7 @@ export class ChromeDevToolsProxyServer {
 
     this.api.Debugger.expose({
       enable: notImplemented,
+      evaluateOnCallFrame: request => this.delegate.cmdEvaluateOnCallFrame(request),
       setSkipAllPauses: async (params) => {
         this.skipAllPauses = params.skip;
       },
@@ -127,6 +132,7 @@ export class ChromeDevToolsProxyServer {
     this.api.Profiler.expose({ enable: notImplemented });
     this.api.Runtime.expose({
       enable: notImplemented,
+      evaluate: request => this.delegate.cmdEvaluate(request),
       runIfWaitingForDebugger: async () => {
         // how could i chain this to happen after the enable response goes out?
         this.api.Runtime.emitExecutionContextCreated({

--- a/jerry-debugger/src/lib/protocol-handler.ts
+++ b/jerry-debugger/src/lib/protocol-handler.ts
@@ -103,7 +103,6 @@ export class JerryDebugProtocolHandler {
 
   private nextScriptID: number = 1;
   private exceptionData?: Uint8Array;
-  private evalQueue: Array<string> = [];
   private evalsPending: number = 0;
   private lastBreakpointHit?: Breakpoint;
   private lastBreakpointExact: boolean = true;
@@ -457,14 +456,6 @@ export class JerryDebugProtocolHandler {
     if (this.delegate.onBreakpointHit) {
       this.delegate.onBreakpointHit(breakpointRef);
     }
-
-    while (true) {
-      const expression = this.evalQueue.shift();
-      if (expression === undefined) {
-        break;
-      }
-      this.evaluate(expression);
-    }
   }
 
   onBacktrace(data: Uint8Array) {
@@ -538,8 +529,7 @@ export class JerryDebugProtocolHandler {
 
   evaluate(expression: string) {
     if (!this.lastBreakpointHit) {
-      this.evalQueue.push(expression);
-      return;
+      throw new Error('attempted eval while not at breakpoint');
     }
 
     this.evalsPending++;

--- a/jerry-debugger/src/lib/protocol-handler.ts
+++ b/jerry-debugger/src/lib/protocol-handler.ts
@@ -96,7 +96,6 @@ export class JerryDebugProtocolHandler {
   private sourceNameData?: Uint8Array;
   private functionName?: string;
   private functionNameData?: Uint8Array;
-  private evalResult?: string;
   private evalResultData?: Uint8Array;
   private functions: FunctionMap = {};
   private newFunctions: FunctionMap = {};
@@ -108,7 +107,6 @@ export class JerryDebugProtocolHandler {
   private evalsPending: number = 0;
   private lastBreakpointHit?: Breakpoint;
   private lastBreakpointExact: boolean = true;
-  private lastBacktrace?: Array<Breakpoint>;
   private activeBreakpoints: Array<Breakpoint> = [];
   private nextBreakpointIndex: number = 0;
 
@@ -143,10 +141,7 @@ export class JerryDebugProtocolHandler {
 
   // FIXME: this lets test suite run for now
   unused() {
-    this.maxMessageSize;
     this.lastBreakpointExact;
-    this.lastBacktrace;
-    this.evalResult;
   }
 
   stepOver() {
@@ -483,7 +478,6 @@ export class JerryDebugProtocolHandler {
       if (this.delegate.onBacktrace) {
         this.delegate.onBacktrace(this.backtrace);
       }
-      this.lastBacktrace = this.backtrace;
       this.backtrace = [];
     }
   }
@@ -632,7 +626,6 @@ export class JerryDebugProtocolHandler {
       throw new Error('attempted resume while not at breakpoint');
     }
     this.lastBreakpointHit = undefined;
-    this.lastBacktrace = undefined;
     this.debuggerClient!.send(encodeMessage(this.byteConfig, 'B', [code]));
     if (this.delegate.onResume) {
       this.delegate.onResume();

--- a/jerry-debugger/src/lib/protocol-handler.ts
+++ b/jerry-debugger/src/lib/protocol-handler.ts
@@ -14,7 +14,8 @@
 
 import * as SP from './jrs-protocol-constants';
 import { Breakpoint, ParsedFunction } from './breakpoint';
-import { ByteConfig, cesu8ToString, assembleUint8Arrays, decodeMessage, encodeMessage } from './utils';
+import { ByteConfig, cesu8ToString, assembleUint8Arrays, decodeMessage, encodeMessage,
+  stringToCesu8, setUint32 } from './utils';
 import { JerryDebuggerClient } from './debugger-client';
 
 export type CompressedPointer = number;
@@ -36,9 +37,10 @@ export interface ParserStackFrame {
 }
 
 export interface JerryDebugProtocolDelegate {
-  onError?(code: number, message: string): void;
   onBacktrace?(backtrace: Array<Breakpoint>): void;
   onBreakpointHit?(message: JerryMessageBreakpointHit): void;
+  onEvalResult?(subType: number, result: string): void;
+  onError?(code: number, message: string): void;
   onResume?(): void;
   onScriptParsed?(message: JerryMessageScriptParsed): void;
 }
@@ -94,14 +96,19 @@ export class JerryDebugProtocolHandler {
   private sourceNameData?: Uint8Array;
   private functionName?: string;
   private functionNameData?: Uint8Array;
+  private evalResult?: string;
+  private evalResultData?: Uint8Array;
   private functions: FunctionMap = {};
   private newFunctions: FunctionMap = {};
   private backtrace: Array<Breakpoint> = [];
 
   private nextScriptID: number = 1;
   private exceptionData?: Uint8Array;
+  private evalQueue: Array<string> = [];
+  private evalsPending: number = 0;
   private lastBreakpointHit?: Breakpoint;
   private lastBreakpointExact: boolean = true;
+  private lastBacktrace?: Array<Breakpoint>;
   private activeBreakpoints: Array<Breakpoint> = [];
   private nextBreakpointIndex: number = 0;
 
@@ -129,13 +136,17 @@ export class JerryDebugProtocolHandler {
       [SP.JERRY_DEBUGGER_BREAKPOINT_HIT]: this.onBreakpointHit,
       [SP.JERRY_DEBUGGER_BACKTRACE]: this.onBacktrace,
       [SP.JERRY_DEBUGGER_BACKTRACE_END]: this.onBacktrace,
+      [SP.JERRY_DEBUGGER_EVAL_RESULT]: this.onEvalResult,
+      [SP.JERRY_DEBUGGER_EVAL_RESULT_END]: this.onEvalResult,
     };
   }
 
   // FIXME: this lets test suite run for now
   unused() {
-    this.maxMessageSize,
+    this.maxMessageSize;
     this.lastBreakpointExact;
+    this.lastBacktrace;
+    this.evalResult;
   }
 
   stepOver() {
@@ -189,7 +200,7 @@ export class JerryDebugProtocolHandler {
   }
 
   onConfiguration(data: Uint8Array) {
-    console.log('[Configuration]');
+    this.logPacket('Configuration');
     if (data.length < 5) {
       this.abort('configuration message wrong size');
       return;
@@ -210,7 +221,11 @@ export class JerryDebugProtocolHandler {
   }
 
   onByteCodeCP(data: Uint8Array) {
-    console.log('[Byte Code CP]');
+    this.logPacket('Byte Code CP', true);
+    if (this.evalsPending) {
+      return;
+    }
+
     const frame = this.stack.pop();
     if (!frame) {
       throw new Error('missing parser stack frame');
@@ -251,7 +266,7 @@ export class JerryDebugProtocolHandler {
   }
 
   onParseFunction(data: Uint8Array) {
-    console.log('[Parse Function]');
+    this.logPacket('Parse Function');
     const position = this.decodeMessage('II', data, 1);
     this.stack.push({
       isFunc: true,
@@ -269,7 +284,11 @@ export class JerryDebugProtocolHandler {
   }
 
   onBreakpointList(data: Uint8Array) {
-    console.log('[Breakpoint List]');
+    this.logPacket('Breakpoint List', true);
+    if (this.evalsPending) {
+      return;
+    }
+
     if (data.byteLength % 4 !== 1 || data.byteLength < 1 + 4) {
       throw new Error('unexpected breakpoint list message length');
     }
@@ -288,7 +307,10 @@ export class JerryDebugProtocolHandler {
   }
 
   onSourceCode(data: Uint8Array) {
-    console.log('[Source Code]');
+    this.logPacket('Source Code', true);
+    if (this.evalsPending) {
+      return;
+    }
 
     if (this.stack.length === 0) {
       this.stack = [{
@@ -322,7 +344,7 @@ export class JerryDebugProtocolHandler {
   }
 
   onSourceCodeName(data: Uint8Array) {
-    console.log('[Source Code Name]');
+    this.logPacket('Source Code Name');
     this.sourceNameData = assembleUint8Arrays(this.sourceNameData, data);
     if (data[0] === SP.JERRY_DEBUGGER_SOURCE_CODE_NAME_END) {
       this.sourceName = cesu8ToString(this.sourceNameData);
@@ -333,7 +355,7 @@ export class JerryDebugProtocolHandler {
   }
 
   onFunctionName(data: Uint8Array) {
-    console.log('[Function Name]', data);
+    this.logPacket('Function Name');
     this.functionNameData = assembleUint8Arrays(this.functionNameData, data);
     if (data[0] === SP.JERRY_DEBUGGER_FUNCTION_NAME_END) {
       this.functionName = cesu8ToString(this.functionNameData);
@@ -341,8 +363,34 @@ export class JerryDebugProtocolHandler {
     }
   }
 
+  releaseFunction(byteCodeCP: number) {
+    const func = this.functions[byteCodeCP];
+
+    const lineList = this.lineLists[func.scriptId];
+    for (const i in func.lines) {
+      const array = lineList[i];
+      const index = array.indexOf(func);
+      array.splice(index, 1);
+
+      const breakpoint = func.lines[i];
+      if (breakpoint.activeIndex >= 0) {
+        delete this.activeBreakpoints[breakpoint.activeIndex];
+      }
+    }
+
+    delete this.functions[byteCodeCP];
+  }
+
   onReleaseByteCodeCP(data: Uint8Array) {
-    console.log('[Release Byte Code CP]');
+    this.logPacket('Release Byte Code CP', true);
+    if (!this.evalsPending) {
+      const byteCodeCP = this.decodeMessage('C', data, 1)[0];
+      if (byteCodeCP in this.newFunctions) {
+        delete this.newFunctions[byteCodeCP];
+      } else {
+        this.releaseFunction(byteCodeCP);
+      }
+    }
 
     // just patch up incoming message
     data[0] = SP.JERRY_DEBUGGER_FREE_BYTE_CODE_CP;
@@ -382,7 +430,11 @@ export class JerryDebugProtocolHandler {
   }
 
   onBreakpointHit(data: Uint8Array) {
-    console.log('[Breakpoint Hit]');
+    if (data[0] === SP.JERRY_DEBUGGER_BREAKPOINT_HIT) {
+      this.logPacket('Breakpoint Hit');
+    } else {
+      this.logPacket('Exception Hit');
+    }
     const breakpointData = this.decodeMessage('CI', data, 1);
     const breakpointRef = this.getBreakpoint(breakpointData);
     const breakpoint = breakpointRef.breakpoint;
@@ -410,19 +462,43 @@ export class JerryDebugProtocolHandler {
     if (this.delegate.onBreakpointHit) {
       this.delegate.onBreakpointHit(breakpointRef);
     }
+
+    while (true) {
+      const expression = this.evalQueue.shift();
+      if (expression === undefined) {
+        break;
+      }
+      this.evaluate(expression);
+    }
   }
 
-  onBacktrace(message: Uint8Array) {
-    for (let i = 1; i < message.byteLength; i += this.byteConfig.cpointerSize + 4) {
-      const breakpointData = this.decodeMessage('CI', message, i);
+  onBacktrace(data: Uint8Array) {
+    this.logPacket('Backtrace');
+    for (let i = 1; i < data.byteLength; i += this.byteConfig.cpointerSize + 4) {
+      const breakpointData = this.decodeMessage('CI', data, i);
       this.backtrace.push(this.getBreakpoint(breakpointData).breakpoint);
     }
 
-    if (message[0] === SP.JERRY_DEBUGGER_BACKTRACE_END) {
+    if (data[0] === SP.JERRY_DEBUGGER_BACKTRACE_END) {
       if (this.delegate.onBacktrace) {
         this.delegate.onBacktrace(this.backtrace);
       }
+      this.lastBacktrace = this.backtrace;
       this.backtrace = [];
+    }
+  }
+
+  onEvalResult(data: Uint8Array) {
+    this.logPacket('Eval Result');
+    this.evalResultData = assembleUint8Arrays(this.evalResultData, data);
+    if (data[0] === SP.JERRY_DEBUGGER_EVAL_RESULT_END) {
+      const subType = data[data.length - 1];
+      const evalResult = cesu8ToString(this.evalResultData.slice(0, -1));
+      if (this.delegate.onEvalResult) {
+        this.delegate.onEvalResult(subType, evalResult);
+      }
+      this.evalResultData = undefined;
+      this.evalsPending--;
     }
   }
 
@@ -464,6 +540,30 @@ export class JerryDebugProtocolHandler {
 
   getActiveBreakpoint(breakpointId: number) {
     return this.activeBreakpoints[breakpointId];
+  }
+
+  evaluate(expression: string) {
+    if (!this.lastBreakpointHit) {
+      this.evalQueue.push(expression);
+      return;
+    }
+
+    this.evalsPending++;
+
+    // send an _EVAL message prefixed with the byte length, followed by _EVAL_PARTs if necessary
+    const array = stringToCesu8(expression, 1 + 4);
+    const arrayLength = array.byteLength;
+    const byteLength = arrayLength - 1 - 4;
+    array[0] = SP.JERRY_DEBUGGER_EVAL;
+    setUint32(this.byteConfig.littleEndian, array, 1, byteLength);
+
+    let offset = 0;
+    while (offset < arrayLength - 1) {
+      const clamped = Math.min(arrayLength - offset, this.maxMessageSize);
+      this.debuggerClient!.send(array.slice(offset, offset + clamped));
+      offset += clamped - 1;
+      array[offset] = SP.JERRY_DEBUGGER_EVAL_PART;
+    }
   }
 
   findBreakpoint(scriptId: number, line: number, column: number = 0) {
@@ -514,6 +614,12 @@ export class JerryDebugProtocolHandler {
     this.debuggerClient!.send(encodeMessage(this.byteConfig, 'BI', [SP.JERRY_DEBUGGER_GET_BACKTRACE, 0]));
   }
 
+  logPacket(description: string, ignorable: boolean = false) {
+    // certain packets are ignored while evals are pending
+    const ignored = (ignorable && this.evalsPending) ? 'Ignored: ' : '';
+    console.log(`[${ignored}${description}]`);
+  }
+
   private abort(message: string) {
     if (this.delegate.onError) {
       console.log('Abort:', message);
@@ -526,6 +632,7 @@ export class JerryDebugProtocolHandler {
       throw new Error('attempted resume while not at breakpoint');
     }
     this.lastBreakpointHit = undefined;
+    this.lastBacktrace = undefined;
     this.debuggerClient!.send(encodeMessage(this.byteConfig, 'B', [code]));
     if (this.delegate.onResume) {
       this.delegate.onResume();

--- a/jerry-debugger/src/lib/utils.ts
+++ b/jerry-debugger/src/lib/utils.ts
@@ -231,6 +231,45 @@ export function cesu8ToString(array: Uint8Array | undefined) {
   return result;
 }
 
+/**
+ * Convert a string to Uint8Array buffer in cesu8 format, with optional left padding
+ *
+ * @param str String to convert
+ * @param offset Optional number of padding bytes to allocate at the beginning
+ */
+export function stringToCesu8(str: string, offset: number = 0) {
+  const length = str.length;
+  let byteLength = length;
+  for (let i = 0; i < length; i++) {
+    const chr = str.charCodeAt(i);
+
+    if (chr > 0x7ff) {
+      byteLength++;
+    }
+
+    if (chr >= 0x7f) {
+      byteLength++;
+    }
+  }
+
+  const result = new Uint8Array(offset + byteLength);
+  for (let i = 0; i < length; i++) {
+    const chr = str.charCodeAt(i);
+
+    if (chr > 0x7ff) {
+      result[offset++] = 0xe0 | (chr >> 12);
+      result[offset++] = 0x80 | ((chr >> 6) & 0x3f);
+      result[offset++] = 0x80 | (chr & 0x3f);
+    } else if (chr >= 0x7f) {
+      result[offset++] = 0xc0 | (chr >> 6);
+      result[offset++] = 0x80 | (chr & 0x3f);
+    } else {
+      result[offset++] = chr;
+    }
+  }
+  return result;
+}
+
 // Concat the two arrays. The first byte (opcode) of nextArray is ignored.
 export function assembleUint8Arrays(baseArray: Uint8Array | undefined, nextArray: Uint8Array) {
   if (!baseArray) {


### PR DESCRIPTION
Caveat: JerryScript only returns a string representation of the eval
  result, so the patch acts like everything is a string. CDT would
  prefer to get typed information and progressively disclose object
  contents, for example, but this would require JrS enhancments.
Caveat: Ignores script parsing messages during eval, but this may need
  to be restored later to allow debugging inside eval'd code.
Chrome sometimes issues eval request while code is running, which
  JerryScript doesn't allow, so they are queued up in that case.
Add unit tests for nearly all of the added code.

JerryScript-DCO-1.0-Signed-off-by: Geoff Gustafson geoff@linux.intel.com